### PR TITLE
fix(ios): fixed j2objc versioining

### DIFF
--- a/actor-apps/app-ios/ActorApp.xcodeproj/project.pbxproj
+++ b/actor-apps/app-ios/ActorApp.xcodeproj/project.pbxproj
@@ -1290,7 +1290,7 @@
 				INFOPLIST_FILE = "ActorApp/Supporting Files/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "../build-tools/dist/j2objc-0.9.8.2/lib";
+				LIBRARY_SEARCH_PATHS = "../build-tools/dist/j2objc-0.9.8.2.1/lib";
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -1343,7 +1343,7 @@
 				PROVISIONING_PROFILE = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "ActorApp/Supporting Files/ActorApp-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				USER_HEADER_SEARCH_PATHS = "ActorCore/Sources ../build-tools/dist/j2objc-0.9.8.2/include";
+				USER_HEADER_SEARCH_PATHS = "ActorCore/Sources ../build-tools/dist/j2objc-0.9.8.2.1/include";
 			};
 			name = Debug;
 		};
@@ -1402,7 +1402,7 @@
 				INFOPLIST_FILE = "ActorApp/Supporting Files/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "../build-tools/dist/j2objc-0.9.8.2/lib";
+				LIBRARY_SEARCH_PATHS = "../build-tools/dist/j2objc-0.9.8.2.1/lib";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -1454,7 +1454,7 @@
 				PROVISIONING_PROFILE = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "ActorApp/Supporting Files/ActorApp-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				USER_HEADER_SEARCH_PATHS = "ActorCore/Sources ../build-tools/dist/j2objc-0.9.8.2/include";
+				USER_HEADER_SEARCH_PATHS = "ActorCore/Sources ../build-tools/dist/j2objc-0.9.8.2.1/include";
 			};
 			name = Release;
 		};

--- a/actor-apps/app-ios/ActorCore/Makefile
+++ b/actor-apps/app-ios/ActorCore/Makefile
@@ -34,7 +34,7 @@ endif
 null :=
 space := ${null} ${null}
 
-J2OBJC_DISTRIBUTION = $(APPS_ROOT)/build-tools/dist/j2objc-0.9.8.2
+J2OBJC_DISTRIBUTION = $(APPS_ROOT)/build-tools/dist/j2objc-0.9.8.2.1
 J2OBJC = $(J2OBJC_DISTRIBUTION)/j2objc
 J2OBJCC = $(J2OBJC_DISTRIBUTION)/j2objcc
 J2OBJC_ARGS = -use-arc --generate-deprecated --doc-comments -g --static-accessor-methods

--- a/actor-apps/build-tools/configureCocoaDeps.sh
+++ b/actor-apps/build-tools/configureCocoaDeps.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Configuration
-J2OBJC_VERSION=0.9.8.2
+J2OBJC_VERSION=0.9.8.2.1
 BUILD_DIRECTORY="$1/build-tools"
 J2OBJC_DIR="${BUILD_DIRECTORY}/dist/"
 


### PR DESCRIPTION
Moved j2objc 0.9.8.2 to 0.9.8.2.1

![jsobjc 0.9.8.2 release](https://github.com/google/j2objc/releases) is marked with following warning.

> Note: the release build for 0.9.8.2 failed, as it did not contain the Guava libraries. Use the 0.9.8.2.1 build instead.