### PR TITLE
Update build.gradle dependency to fix build

### DIFF
--- a/actor-apps/app-android/build.gradle
+++ b/actor-apps/app-android/build.gradle
@@ -152,7 +152,7 @@ dependencies {
         exclude module: 'support-v13'
     }
     compile 'com.getbase:floatingactionbutton:1.5.1'
-    compile 'com.afollestad:material-dialogs:0.7.3.1'
+    compile 'com.afollestad:material-dialogs:0.7.9.1'
     compile 'org.pegdown:pegdown:1.5.0'
 
     // Phone parser


### PR DESCRIPTION
I updated dependency of "com.afollestad:material-dialogs" to version 0.7.9.1 to fix build error. Looks like 0.7.3.1 is missing as per this thread https://github.com/WhisperSystems/TextSecure/issues/4138#issuecomment-143987932.