### PR TITLE
fix(ios): fixed crash when sharing contacts with empty firstname and/or lastname

### DIFF
--- a/actor-sdk/sdk-core-ios/ActorSDK/Sources/Controllers/Conversation/ConversationViewController.swift
+++ b/actor-sdk/sdk-core-ios/ActorSDK/Sources/Controllers/Conversation/ConversationViewController.swift
@@ -498,10 +498,8 @@ class ConversationViewController: AAConversationContentController, UIDocumentMen
         
         // Names
         
-        let firstname: ABMultiValueRef = ABRecordCopyValue(person, kABPersonFirstNameProperty).takeRetainedValue()
-        let lastname: ABMultiValueRef = ABRecordCopyValue(person, kABPersonLastNameProperty).takeRetainedValue()
-        let name = (firstname.description + " " + lastname.description).trim()
-
+        let name = ABRecordCopyCompositeName(person)?.takeRetainedValue() as String?
+        
         // Avatar
         
         var jAvatarImage: String? = nil


### PR DESCRIPTION
If contact selected for sharing has empty firstname or lastname you got a crash. 
Also "Company" field is not taking into consideration for contacts with empty name but filled company (for example standard "Apple Inc." entry predefined in each address book).
Fixed that. 