### PR TITLE
fix(ios): fixed crash when deleting last dialog item in iOS8

### DIFF
--- a/actor-sdk/sdk-core-ios/ActorSDK/Sources/Controllers/Content/Conversation/Layouting/AAMessagesFlowLayout.swift
+++ b/actor-sdk/sdk-core-ios/ActorSDK/Sources/Controllers/Content/Conversation/Layouting/AAMessagesFlowLayout.swift
@@ -114,9 +114,9 @@ class AAMessagesFlowLayout : UICollectionViewLayout {
         deletedIndexPaths.removeAll(keepCapacity: true)
         for update in updateItems {
             if update.updateAction == .Insert {
-                insertedIndexPaths.append(update.indexPathAfterUpdate)
+                insertedIndexPaths.append(update.indexPathAfterUpdate!)
             } else if update.updateAction == .Delete {
-                deletedIndexPaths.append(update.indexPathBeforeUpdate)
+                deletedIndexPaths.append(update.indexPathBeforeUpdate!)
             }
         }
         if ENABLE_LOGS { print("prepareForCollectionViewUpdates: \(CFAbsoluteTimeGetCurrent() - start)") }

--- a/actor-sdk/sdk-core-ios/ActorSDK/Sources/Controllers/Conversation/ConversationViewController.swift
+++ b/actor-sdk/sdk-core-ios/ActorSDK/Sources/Controllers/Conversation/ConversationViewController.swift
@@ -498,10 +498,8 @@ class ConversationViewController: AAConversationContentController, UIDocumentMen
         
         // Names
         
-        let firstname: ABMultiValueRef = ABRecordCopyValue(person, kABPersonFirstNameProperty).takeRetainedValue()
-        let lastname: ABMultiValueRef = ABRecordCopyValue(person, kABPersonLastNameProperty).takeRetainedValue()
-        let name = (firstname.description + " " + lastname.description).trim()
-
+        let name = ABRecordCopyCompositeName(person)?.takeRetainedValue() as String?
+        
         // Avatar
         
         var jAvatarImage: String? = nil

--- a/actor-sdk/sdk-core-ios/ActorSDK/Sources/Controllers/Managed Runtime/AAManagedTable.swift
+++ b/actor-sdk/sdk-core-ios/ActorSDK/Sources/Controllers/Managed Runtime/AAManagedTable.swift
@@ -320,7 +320,7 @@ private class AMBaseTableDelegate: NSObject, UITableViewDelegate, UITableViewDat
     }
     
     @objc func tableView(tableView: UITableView, canEditRowAtIndexPath indexPath: NSIndexPath) -> Bool {
-        return data.sections[indexPath.section].canDelete(data, indexPath: indexPath)
+        return (data.sections[indexPath.section].numberOfItems(data) > 0 ? data.sections[indexPath.section].canDelete(data, indexPath: indexPath) : false)
     }
     
     @objc func tableView(tableView: UITableView, canMoveRowAtIndexPath indexPath: NSIndexPath) -> Bool {


### PR DESCRIPTION
When removing last dialog item in the list in iOS8 your got crash (no issue in iOS9).
This issue was already reported in https://github.com/actorapp/actor-platform/issues/152.