### PR TITLE
Updated text in version cell of Settings screen

### DIFF
--- a/actor-sdk/sdk-core-ios/ActorSDK/Sources/Controllers/Settings/AASettingsViewController.swift
+++ b/actor-sdk/sdk-core-ios/ActorSDK/Sources/Controllers/Settings/AASettingsViewController.swift
@@ -351,7 +351,7 @@ public class AASettingsViewController: AAContentTableController {
 
             // Support: App version
             let version = NSBundle.mainBundle().infoDictionary!["CFBundleShortVersionString"] as! String
-            s.hint(version.replace("{version}", dest: version))
+            s.hint(AALocalized("SettingsVersion").replace("{version}", dest: version))
             
             ActorSDK.sharedActor().delegate.actorSettingsSupportDidCreated(self, section: s)
         }


### PR DESCRIPTION
Localized version string is not applied for cell. Added that.