### PR TITLE
Fixed bug with broken "Message preview" notification option

### DIFF
--- a/actor-server/actor-core/src/main/scala/im/actor/server/sequence/VendorPush.scala
+++ b/actor-server/actor-core/src/main/scala/im/actor/server/sequence/VendorPush.scala
@@ -49,7 +49,7 @@ private object SettingsKeys {
 
   def vibrationEnabled(deviceType: String) = wrapEnabled(deviceType, "vibration")
 
-  def textEnabled(deviceType: String) = wrapEnabled(deviceType, "show_text")
+  def textEnabled(deviceType: String) = wrap(deviceType, "show_text")
 
   def peerEnabled(deviceType: String, peer: Peer) = wrapEnabled(deviceType, s"chat.${peerStr(peer)}")
 }


### PR DESCRIPTION
**"Message preview"** privacy option of "Notification and Sounds" settings doesn't work properly. It doesn't matter if it is enabled or disabled - the push notification always contains message text because the wrong option name is used to query for corresponding settings.
Currently server gets the option value by *"category.mobile.notification.show_text.enabled"* key instead of *"category.mobile.notification.show_text"*.
Fixed that.