### PR TITLE
Fix crash on inviting contacts via SMS

### DIFF
--- a/actor-sdk/sdk-core-ios/ActorSDK/Sources/Controllers/Contacts/AAContactsViewController.swift
+++ b/actor-sdk/sdk-core-ios/ActorSDK/Sources/Controllers/Contacts/AAContactsViewController.swift
@@ -227,6 +227,9 @@ class AAContactsViewController: AAContactsListContentController, AAContactsListC
     }
     
     // SMS Invitation
+    func showSmsInvitation() {
+        self.showSmsInvitation(nil)
+    }
     
     func showSmsInvitation(recipients: [String]?) {
         if MFMessageComposeViewController.canSendText() {


### PR DESCRIPTION
When pressing **"TELL A FRIEND"** on contact screen placeholder you get a crash on opening SMS composer. Fixed that.