### PR TITLE
Disable "Send Document" when iCloud is closed

### DIFF
--- a/actor-sdk/sdk-core-ios/ActorSDK/Sources/Controllers/Conversation/ConversationViewController.swift
+++ b/actor-sdk/sdk-core-ios/ActorSDK/Sources/Controllers/Conversation/ConversationViewController.swift
@@ -477,8 +477,10 @@ class ConversationViewController: AAConversationContentController, UIDocumentMen
             self.pickImage(.PhotoLibrary)
         }
         
-        builder.add("SendDocument") {
-            self.pickDocument()
+        if (NSFileManager.defaultManager().ubiquityIdentityToken != nil) {
+            builder.add("SendDocument") {
+                self.pickDocument()
+            }
         }
         
         builder.add("ShareLocation") {


### PR DESCRIPTION
It would be confusing to end user