### PR TITLE
fixes backgroundView image escaping superview

### DIFF
--- a/actor-sdk/sdk-core-ios/ActorSDK/Sources/Controllers/Conversation/ConversationViewController.swift
+++ b/actor-sdk/sdk-core-ios/ActorSDK/Sources/Controllers/Conversation/ConversationViewController.swift
@@ -67,6 +67,7 @@ class ConversationViewController: AAConversationContentController, UIDocumentMen
         
         // Background
         
+        backgroundView.clipsToBounds = true
         backgroundView.contentMode = .ScaleAspectFill
         backgroundView.backgroundColor = appStyle.chatBgColor
         


### PR DESCRIPTION
When having a custom background image, and navigating back from a conversation, the background image would be bigger than superview and still be visible for a second on top of previous controller