### PR TITLE
feat(ios): Make links in text messages copyable

### DIFF
--- a/actor-sdk/sdk-core-ios/ActorSDK/Resources/Base.lproj/Localizable.strings
+++ b/actor-sdk/sdk-core-ios/ActorSDK/Resources/Base.lproj/Localizable.strings
@@ -507,6 +507,10 @@
 
 "AlertLinkCopied" = "Link copied to clipboard.";
 
+"ActionOpenLink" = "Open Link";
+
+"ActionCancel" = "Cancel";
+
 /*
  *  Network
  */

--- a/actor-sdk/sdk-core-ios/ActorSDK/Resources/es.lproj/Localizable.strings
+++ b/actor-sdk/sdk-core-ios/ActorSDK/Resources/es.lproj/Localizable.strings
@@ -504,6 +504,10 @@
 
 "AlertLinkCopied" = "Enlace copiado al portapapeles.";
 
+"ActionOpenLink" = "Enlace abierto";
+
+"ActionCancel" = "Cancelar";
+
 /*
  * Network
  */

--- a/actor-sdk/sdk-core-ios/ActorSDK/Resources/pt.lproj/Localizable.strings
+++ b/actor-sdk/sdk-core-ios/ActorSDK/Resources/pt.lproj/Localizable.strings
@@ -483,6 +483,10 @@
 
 "AlertLinkCopied" = "Link copiado para a área de transferência.";
 
+"ActionOpenLink" = "Link Aberto";
+
+"ActionCancel" = "Cancelar";
+
 /*
  * Network
  */

--- a/actor-sdk/sdk-core-ios/ActorSDK/Resources/ru.lproj/Localizable.strings
+++ b/actor-sdk/sdk-core-ios/ActorSDK/Resources/ru.lproj/Localizable.strings
@@ -497,6 +497,10 @@
 
 "AlertLinkCopied" = "Ссылка скопирована в буфер обмена.";
 
+"ActionOpenLink" = "Открыть ссылку";
+
+"ActionCancel" = "Отмена";
+
 /*
  * Network
  */

--- a/actor-sdk/sdk-core-ios/ActorSDK/Resources/zh-Hans.lproj/Localizable.strings
+++ b/actor-sdk/sdk-core-ios/ActorSDK/Resources/zh-Hans.lproj/Localizable.strings
@@ -487,6 +487,10 @@
 
 "AlertLinkCopied" = "链接已经被复制到剪贴板。";
 
+"ActionOpenLink" = "打开链接";
+
+"ActionCancel" = "取消";
+
 /*
  * Network
  */

--- a/actor-sdk/sdk-core-ios/ActorSDK/Sources/Controllers/Content/Conversation/Cell/AABubbleTextCell.swift
+++ b/actor-sdk/sdk-core-ios/ActorSDK/Sources/Controllers/Content/Conversation/Cell/AABubbleTextCell.swift
@@ -205,7 +205,16 @@ public class AABubbleTextCell : AABubbleCell, TTTAttributedLabelDelegate {
     // Url open handling
     
     public func attributedLabel(label: TTTAttributedLabel!, didLongPressLinkWithURL url: NSURL!, atPoint point: CGPoint) {
-        openUrl(url)
+        let actionSheet: UIAlertController = UIAlertController(title: nil, message: url.absoluteString, preferredStyle: .ActionSheet)
+        actionSheet.addAction(UIAlertAction(title: AALocalized("ActionOpenLink"), style: .Default, handler: { action in
+            self.openUrl(url)
+        }))
+        actionSheet.addAction(UIAlertAction(title: AALocalized("ActionCopyLink"), style: .Default, handler: { action in
+            UIPasteboard.generalPasteboard().string = url.absoluteString
+            self.controller.alertUser("AlertLinkCopied")
+        }))
+        actionSheet.addAction(UIAlertAction(title: AALocalized("ActionCancel"), style: .Cancel, handler:nil))
+        self.controller.presentViewController(actionSheet, animated: true, completion: nil)
     }
     
     public func attributedLabel(label: TTTAttributedLabel!, didSelectLinkWithURL url: NSURL!) {


### PR DESCRIPTION
At the moment links in text messages are not copyable (URL is opened in browser when link is pressed).
Added action sheet with "Copy link"/"Open link" options to handle link pressing properly.