### PR TITLE
fix(android): add the GCM google_app_id to strings.xml

### DIFF
--- a/actor-sdk/sdk-core-android/android-app/src/main/res/values/strings.xml
+++ b/actor-sdk/sdk-core-android/android-app/src/main/res/values/strings.xml
@@ -4,4 +4,5 @@
 
     <string name="hello_world">Hello world!</string>
     <string name="action_settings">Settings</string>
+    <string name="google_app_id">209133700967</string>
 </resources>


### PR DESCRIPTION
I got this error:
 GoogleService failed to initialize, status: 10, Missing an expected resource: 'R.string.google_app_id' for initializing Google services.  Possible causes are missing google-services.json or com.google.gms.google-services gradle plugin.

and just add the res id to strings.xml, thats simplest solution?? @kor-ka ?