### PR TITLE
fix(android): fix contactSyncActor null problem in ContactProcessor

### DIFF
--- a/actor-sdk/sdk-core/core/core-shared/src/main/java/im/actor/core/modules/updates/ContactsProcessor.java
+++ b/actor-sdk/sdk-core/core/core-shared/src/main/java/im/actor/core/modules/updates/ContactsProcessor.java
@@ -13,21 +13,18 @@ import im.actor.runtime.annotations.Verified;
 @Verified
 public class ContactsProcessor extends AbsModule {
 
-    private ActorRef contactsSyncActor;
-
     @Verified
     public ContactsProcessor(ModuleContext context) {
         super(context);
-        contactsSyncActor = context().getContactsModule().getContactSyncActor();
     }
 
     @Verified
     public void onContactsAdded(int[] uid) {
-        contactsSyncActor.send(new ContactsSyncActor.ContactsAdded(uid));
+        context().getContactsModule().getContactSyncActor().send(new ContactsSyncActor.ContactsAdded(uid));
     }
 
     @Verified
     public void onContactsRemoved(int[] uid) {
-        contactsSyncActor.send(new ContactsSyncActor.ContactsRemoved(uid));
+        context().getContactsModule().getContactSyncActor().send(new ContactsSyncActor.ContactsRemoved(uid));
     }
 }


### PR DESCRIPTION
its a strange bug, when I have a lot of contact (400+), some time contactsSyncActor ActorRef is going null and onContactsAdded throws an exception.
