### PR TITLE
fix(ios): Updates to auth Terms of Service screen

### DIFF
--- a/actor-sdk/sdk-core-ios/ActorSDK/Resources/Base.lproj/Localizable.strings
+++ b/actor-sdk/sdk-core-ios/ActorSDK/Resources/Base.lproj/Localizable.strings
@@ -409,6 +409,8 @@
 
 "AuthTermsOfService" = "Terms of Service";
 
+"AuthTermsOfServiceTitle" = "Terms of Service";
+
 "AuthPhoneTooShort" = "Phone number too short";
 
 "AuthCodeFieldHint" = "Code";

--- a/actor-sdk/sdk-core-ios/ActorSDK/Resources/es.lproj/Localizable.strings
+++ b/actor-sdk/sdk-core-ios/ActorSDK/Resources/es.lproj/Localizable.strings
@@ -393,11 +393,11 @@
 
 "AuthStarButton" = "Empieza a chatear";
 
-
 "AuthTermsOfServiceFull" = "Al inscribirte,aceptas las Condiciones del servicio.";
 
 "AuthTermsOfService" = "Condiciones del servicio";
 
+"AuthTermsOfServiceTitle" = "Condiciones";
 
 "AuthPhoneTitle" = "Registrarse";
 

--- a/actor-sdk/sdk-core-ios/ActorSDK/Resources/pt.lproj/Localizable.strings
+++ b/actor-sdk/sdk-core-ios/ActorSDK/Resources/pt.lproj/Localizable.strings
@@ -385,6 +385,8 @@
 
 "AuthTermsOfService" = "Termos de Serviço";
 
+"AuthTermsOfServiceTitle" = "Termos";
+
 "AuthPhoneTooShort" = "Número de telefone muito curto";
 
 "AuthCodeFieldHint" = "Código";

--- a/actor-sdk/sdk-core-ios/ActorSDK/Resources/ru.lproj/Localizable.strings
+++ b/actor-sdk/sdk-core-ios/ActorSDK/Resources/ru.lproj/Localizable.strings
@@ -399,6 +399,8 @@
 
 "AuthTermsOfService" = "Условиями предоставления услуг";
 
+"AuthTermsOfServiceTitle" = "Условия";
+
 "AuthPhoneTooShort" = "Номер телефона слишком короткий";
 
 "AuthCodeFieldHint" = "Код активации";
@@ -421,7 +423,7 @@
 
 "AuthProfileHint" = "Введите свое имя и выберите фото";
 
-"AuthTerms" = "By signing up to {app_name}, you agree not to: \n\n - use our service to send spam and scam users.\n- use our service to send spam and scam users.\n- use our service to send spam and scam users.\n- promote violence on publicly viewable {app_name} bots or channels.\n\nWe reserve the right to update these Terms of Service later.";
+"AuthTerms" = "By signing up to {app_name}, you agree not to: \n\n - use our service to send spam and scam users.\n- promote violence on publicly viewable {app_name} bots or channels.\n\nWe reserve the right to update these Terms of Service later.";
 
 /*
  * Common Elements

--- a/actor-sdk/sdk-core-ios/ActorSDK/Resources/zh-Hans.lproj/Localizable.strings
+++ b/actor-sdk/sdk-core-ios/ActorSDK/Resources/zh-Hans.lproj/Localizable.strings
@@ -408,6 +408,8 @@
 
 "AuthTermsOfService" = "服务条款";
 
+"AuthTermsOfServiceTitle" = "服务条款";
+
 "AuthPhoneTooShort" = "电话号码太短";
 
 "AuthCodeFieldHint" = "验证码";

--- a/actor-sdk/sdk-core-ios/ActorSDK/Sources/Controllers/Auth/AATermsController.swift
+++ b/actor-sdk/sdk-core-ios/ActorSDK/Sources/Controllers/Auth/AATermsController.swift
@@ -81,7 +81,7 @@ class AATermsController: UIViewController,UIViewControllerTransitioningDelegate 
         self.alertTitleLabel = UILabel()
         self.alertTitleLabel.font = UIFont(name: "HelveticaNeue-Bold", size: 17)
         self.alertTitleLabel.frame = CGRectMake(10,10,220,30)
-        self.alertTitleLabel.text = AALocalized("AuthTermsOfService")
+        self.alertTitleLabel.text = AALocalized("AuthTermsOfServiceTitle")
         self.alertTitleLabel.backgroundColor = UIColor.clearColor()
         self.alertTitleLabel.textAlignment = .Center
         self.alertView.addSubview(self.alertTitleLabel)
@@ -101,7 +101,7 @@ class AATermsController: UIViewController,UIViewControllerTransitioningDelegate 
         self.alertView.addSubview(separatorView)
         
         self.buttonOk = UIButton(type: UIButtonType.System)
-        self.buttonOk.setTitle("OK", forState: UIControlState.Normal)
+        self.buttonOk.setTitle(AALocalized("AlertOk"), forState: UIControlState.Normal)
         self.buttonOk.setTitleColor(UIColor.blueColor(), forState: UIControlState.Normal)
         self.buttonOk.frame = CGRectMake(0,291,240,39)
         self.buttonOk.addTarget(self, action: "closeController", forControlEvents: UIControlEvents.TouchUpInside)


### PR DESCRIPTION
At the moment the same localized key is used for making "Terms of Service" link on auth screen and terms popup title which looks weird at least for Russian localization:

![simulator screen shot 16 2016 22 55 39](https://cloud.githubusercontent.com/assets/2015453/13092047/b479dc32-d506-11e5-8784-a57fffd26d71.png)

![simulator screen shot 16 2016 22 55 42](https://cloud.githubusercontent.com/assets/2015453/13092048/b804c506-d506-11e5-85cf-ede2394929f7.png)

Also the Terms text includes "use our service to send spam and scam users" 3 times (for Russian localization).
Fixed that:

![simulator screen shot 16 2016 23 43 02](https://cloud.githubusercontent.com/assets/2015453/13092118/0df69926-d507-11e5-8646-76a6fe0efc8c.png)
