### PR TITLE
Bugfix/njv 227 dont create main activity in forwards

### DIFF
--- a/actor-sdk/sdk-core-android/android-sdk/src/main/AndroidManifest.xml
+++ b/actor-sdk/sdk-core-android/android-sdk/src/main/AndroidManifest.xml
@@ -63,6 +63,7 @@
         <activity
             android:name="im.actor.sdk.controllers.activity.ActorMainActivity"
             android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
+            android:launchMode="singleTop"
             android:label="@string/app_name"
             android:theme="@style/MainActivityTheme"
             android:windowSoftInputMode="adjustResize">

--- a/actor-sdk/sdk-core-android/android-sdk/src/main/java/im/actor/sdk/controllers/conversation/messages/MessagesFragment.java
+++ b/actor-sdk/sdk-core-android/android-sdk/src/main/java/im/actor/sdk/controllers/conversation/messages/MessagesFragment.java
@@ -408,6 +408,7 @@ public class MessagesFragment extends DisplayListFragment<Message, MessageHolder
 
                     } else if (menuItem.getItemId() == R.id.forward) {
                         Intent i = new Intent(getActivity(), ActorMainActivity.class);
+                        i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
                         if (messagesAdapter.getSelected().length == 1) {
                             Message m = messagesAdapter.getSelected()[0];
                             if (m.getContent() instanceof TextContent) {
@@ -453,6 +454,7 @@ public class MessagesFragment extends DisplayListFragment<Message, MessageHolder
                         }
                         actionMode.finish();
                         startActivity(i);
+                        getActivity().finish();
                         return true;
                     }
                     return false;

--- a/actor-sdk/sdk-core/core/core-shared/src/main/java/im/actor/core/modules/internal/push/PushRegisterActor.java
+++ b/actor-sdk/sdk-core/core/core-shared/src/main/java/im/actor/core/modules/internal/push/PushRegisterActor.java
@@ -60,7 +60,7 @@ public class PushRegisterActor extends ModuleActor {
 
             @Override
             public void onError(RpcException e) {
-
+                e.printStackTrace();
             }
         });
     }

--- a/actor-sdk/sdk-core/runtime/runtime-shared/src/main/java/im/actor/runtime/promise/PromisesArray.java
+++ b/actor-sdk/sdk-core/runtime/runtime-shared/src/main/java/im/actor/runtime/promise/PromisesArray.java
@@ -30,6 +30,7 @@ public class PromisesArray<T> {
      * @param <T>        type of array
      * @return array
      */
+    @SuppressWarnings("unchecked")
     public static <T> PromisesArray<T> of(Collection<T> collection) {
         final ArrayList<Promise<T>> res = new ArrayList<>();
         for (T t : collection) {
@@ -77,7 +78,7 @@ public class PromisesArray<T> {
     public static <T> PromisesArray<T> ofPromises(Promise<T>... items) {
         ArrayList<Promise<T>> res = new ArrayList<>();
         Collections.addAll(res, items);
-        final Promise[] promises = (Promise[]) res.toArray();
+        final Promise[] promises = res.toArray(new Promise[res.size()]);
         return new PromisesArray<>(new PromiseFunc<Promise<T>[]>() {
             @Override
             public void exec(PromiseResolver<Promise<T>[]> executor) {


### PR DESCRIPTION
when app is in MainActivity, if we press back, usually app should be closed.
but if we forward some message, we get back to original dialog.
this is because app starts new MainActivity in forwards.

-- 
I fix a unrelated minor cast in runtime too