### PR TITLE
feat(server): Added option to support S3 URLs with path-style access

### DIFF
--- a/actor-server/actor-fs-adapters/src/main/resources/reference.conf
+++ b/actor-server/actor-fs-adapters/src/main/resources/reference.conf
@@ -9,6 +9,8 @@ services {
       s3 {
          # provide your custom S3 endpoint if needed
          endpoint: ""
+         # enable S3 URLs with path-style access if needed
+         path-style-access: false
       }
   }
 }

--- a/actor-server/actor-fs-adapters/src/main/scala/im/actor/server/file/s3/S3StorageAdapter.scala
+++ b/actor-server/actor-fs-adapters/src/main/scala/im/actor/server/file/s3/S3StorageAdapter.scala
@@ -9,6 +9,7 @@ import akka.util.ByteString
 import com.amazonaws.HttpMethod
 import com.amazonaws.auth.BasicAWSCredentials
 import com.amazonaws.services.s3.model.{ GeneratePresignedUrlRequest, ObjectMetadata }
+import com.amazonaws.services.s3.S3ClientOptions
 import com.amazonaws.services.s3.transfer.TransferManager
 import com.amazonaws.services.s3.transfer.model.UploadResult
 import com.github.dwhjames.awswrap.s3.{ AmazonS3ScalaClient, FutureTransfer }
@@ -38,6 +39,10 @@ final class S3StorageAdapter(_system: ActorSystem) extends FileStorageAdapter {
   val s3Client = new AmazonS3ScalaClient(awsCredentials)
   if (!config.endpoint.isEmpty) {
     s3Client.client.setEndpoint(config.endpoint)
+
+    if (config.pathStyleAccess) {
+      s3Client.client.setS3ClientOptions(new S3ClientOptions().withPathStyleAccess(true));
+    }
   }
 
   val transferManager = new TransferManager(s3Client.client)

--- a/actor-server/actor-fs-adapters/src/main/scala/im/actor/server/file/s3/S3StorageAdapterConfig.scala
+++ b/actor-server/actor-fs-adapters/src/main/scala/im/actor/server/file/s3/S3StorageAdapterConfig.scala
@@ -5,7 +5,7 @@ import com.typesafe.config.{ ConfigFactory, Config }
 
 import scala.util.Try
 
-case class S3StorageAdapterConfig(bucketName: String, key: String, secret: String, endpoint: String)
+case class S3StorageAdapterConfig(bucketName: String, key: String, secret: String, endpoint: String, pathStyleAccess: Boolean)
 
 object S3StorageAdapterConfig {
   def load(config: Config): Try[S3StorageAdapterConfig] = {
@@ -14,7 +14,8 @@ object S3StorageAdapterConfig {
       key ← config.get[Try[String]]("access-key")
       secret ← config.get[Try[String]]("secret-key")
       endpoint ← config.get[Try[String]]("endpoint")
-    } yield S3StorageAdapterConfig(bucketName, key, secret, endpoint)
+      pathStyleAccess ← config.get[Try[Boolean]]("path-style-access")
+    } yield S3StorageAdapterConfig(bucketName, key, secret, endpoint, pathStyleAccess)
   }
 
   def load: Try[S3StorageAdapterConfig] = {

--- a/actor-server/src/universal/conf/server.conf.example
+++ b/actor-server/src/universal/conf/server.conf.example
@@ -100,6 +100,8 @@ services {
       default-bucket: <put_your_bucket_here>
       # S3 Endpoint
       # endpoint: <put_your_custom_endpoint_here>
+      # Enable S3 URLs with path-style access
+      # path-style-access: true / false
     }
   }
 


### PR DESCRIPTION
For some special S3 configurations like using regional based endpoints and/or HTTPS configurations we should be able to switch S3 fs adapter to path-style access URLs instead of virtual-hosted-style.

> Amazon's Simple Storage Service (S3) provides two different ways to structure your S3 URLs. In the "virtual-hosted-style", your bucket name becomes part of the domain; and, in the "path-style", your bucket name becomes part of the resource (as a prefix to your object key). When you're making requests over HTTP, these two approaches are equivalent. However, when you start making requests over HTTPS (with SSL), things can get complicated. As such, it can be important to be able to tell your Java S3 Client to produce pre-signed URLs using path-style access.

Read more at http://www.bennadel.com/blog/2791-using-the-amazon-web-services-aws-sdk-to-create-pre-signed-s3-urls-with-path-style-access.htm

Added option to enable path-style access. It works only when custom endpoint is set as stated in AWS SDK docs:
> The path-style syntax, however, requires that you use the region-specific endpoint when attempting to access a bucket.

http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/S3ClientOptions.html#setPathStyleAccess(boolean)