### PR TITLE
Fix(android) Wallpaper issue

### DIFF
--- a/actor-sdk/sdk-core-android/android-sdk/src/main/java/im/actor/sdk/ActorStyle.java
+++ b/actor-sdk/sdk-core-android/android-sdk/src/main/java/im/actor/sdk/ActorStyle.java
@@ -21,7 +21,9 @@ public class ActorStyle {
     }
 
     public void setDefaultBackgrouds(int[] defaultBackgrouds) {
-        this.defaultBackgrouds = defaultBackgrouds;
+        if (defaultBackgrouds.length > 0) {
+            this.defaultBackgrouds = defaultBackgrouds;
+        }
     }
 
     //////////////////////////

--- a/actor-sdk/sdk-core-android/android-sdk/src/main/java/im/actor/sdk/controllers/conversation/MessagesFragment.java
+++ b/actor-sdk/sdk-core-android/android-sdk/src/main/java/im/actor/sdk/controllers/conversation/MessagesFragment.java
@@ -118,32 +118,26 @@ public class MessagesFragment extends DisplayListFragment<Message, MessageHolder
             wallpaperPrefs = getContext().getSharedPreferences("wallpaper", Context.MODE_PRIVATE);
         }
         Drawable background;
-        if (messenger().getSelectedWallpaper() == null) {
-            background = getResources().getDrawable(ActorSDK.sharedActor().style.getDefaultBackgrouds()[0]);
-        } else if (messenger().getSelectedWallpaper().equals("local:bg_1")) {
-            if (ActorSDK.sharedActor().style.getDefaultBackgrouds().length > 1) {
-                background = getResources().getDrawable(ActorSDK.sharedActor().style.getDefaultBackgrouds()[1]);
-            } else {
-                background = getResources().getDrawable(ActorSDK.sharedActor().style.getDefaultBackgrouds()[0]);
+
+        int [] backgrounds = ActorSDK.sharedActor().style.getDefaultBackgrouds();
+        String selectedWallpaper = messenger().getSelectedWallpaper();
+
+        if (selectedWallpaper != null) {
+            if (backgrounds.length > 0) {
+                background = getResources().getDrawable(backgrounds[0]);
+                if (selectedWallpaper.startsWith("local")) {
+                    for (int i = 1; i < backgrounds.length; i++) {
+                        if (getResources().getResourceEntryName(backgrounds[i]).equals(selectedWallpaper.replaceAll("local:", ""))) {
+                            background = getResources().getDrawable(backgrounds[i]);
+                        }
+                    }
+                } else {
+                    background = Drawable.createFromPath(BaseActorSettingsFragment.getWallpaperFile());
+                }
+                ((ImageView) res.findViewById(R.id.chatBackgroundView)).setImageDrawable(background);
             }
-        } else if (messenger().getSelectedWallpaper().equals("local:bg_2")) {
-            if (ActorSDK.sharedActor().style.getDefaultBackgrouds().length > 2) {
-                background = getResources().getDrawable(ActorSDK.sharedActor().style.getDefaultBackgrouds()[2]);
-            } else {
-                background = getResources().getDrawable(ActorSDK.sharedActor().style.getDefaultBackgrouds()[0]);
-            }
-        } else if (messenger().getSelectedWallpaper().equals("local:bg_3")) {
-            if (ActorSDK.sharedActor().style.getDefaultBackgrouds().length > 3) {
-                background = getResources().getDrawable(ActorSDK.sharedActor().style.getDefaultBackgrouds()[3]);
-            } else {
-                background = getResources().getDrawable(ActorSDK.sharedActor().style.getDefaultBackgrouds()[0]);
-            }
-        } else if (messenger().getSelectedWallpaper().startsWith("local:")) {
-            background = getResources().getDrawable(ActorSDK.sharedActor().style.getDefaultBackgrouds()[0]);
-        } else {
-            background = Drawable.createFromPath(BaseActorSettingsFragment.getWallpaperFile());
         }
-        ((ImageView) res.findViewById(R.id.chatBackgroundView)).setImageDrawable(background);
+
 
         View footer = new View(getActivity());
         footer.setLayoutParams(new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, Screen.dp(8)));

--- a/actor-sdk/sdk-core-android/android-sdk/src/main/java/im/actor/sdk/controllers/conversation/MessagesFragment.java
+++ b/actor-sdk/sdk-core-android/android-sdk/src/main/java/im/actor/sdk/controllers/conversation/MessagesFragment.java
@@ -125,7 +125,7 @@ public class MessagesFragment extends DisplayListFragment<Message, MessageHolder
         if (selectedWallpaper != null) {
             if (backgrounds.length > 0) {
                 background = getResources().getDrawable(backgrounds[0]);
-                if (selectedWallpaper.startsWith("local")) {
+                if (selectedWallpaper.startsWith("local:")) {
                     for (int i = 1; i < backgrounds.length; i++) {
                         if (getResources().getResourceEntryName(backgrounds[i]).equals(selectedWallpaper.replaceAll("local:", ""))) {
                             background = getResources().getDrawable(backgrounds[i]);


### PR DESCRIPTION
Issue: Change predefined wallpaper-resources in actor-sdk is hardcoded by name "bg_1, bg_2, bg_3". Append or change predefined wallpaper in custom android-app is hard.

After refactoring possibly in custom android-app use any image resources, e.g. in _onConfigureActorSDK()_:

change all predefined wallpapers:

```
ActorStyle style = ActorSDK.sharedActor().style;

int [] backgrounds = new int[]{R.drawable.funny_bg, R.drawable.wallpaper, R.drawable.image42};
style.setDefaultBackgrouds(backgrounds);
```

or add to the existing bg_1, bg_2, bg_3:

```
ActorStyle style = ActorSDK.sharedActor().style;

int [] backgrounds = ArrayUtils.appendInt(style.getDefaultBackgrouds(), R.drawable.funny_bg);
style.setDefaultBackgrouds(backgrounds);
```

