### PR TITLE
Markdown issue

### DIFF
--- a/actor-sdk/sdk-core/runtime/runtime-shared/src/main/java/im/actor/runtime/markdown/MarkdownParser.java
+++ b/actor-sdk/sdk-core/runtime/runtime-shared/src/main/java/im/actor/runtime/markdown/MarkdownParser.java
@@ -374,10 +374,10 @@ public class MarkdownParser {
      * @return is good anchor
      */
     private boolean isGoodAnchor(String text, int index) {
-        // Check if there is space after block
+        // Check if there is space and punctuation mark after block
+        String punct = " .,:!?\t\n";
         if (index >= 0 && index < text.length()) {
-            char postfix = text.charAt(index);
-            if (postfix != ' ' && postfix != '\t' && postfix != '\n') {
+            if (punct.indexOf(text.charAt(index)) == -1) {
                 return false;
             }
         }


### PR DESCRIPTION
Issue #278 resolved:

Incorrect formatting if text ends punctuation mark:
"`_italic_`" - correct _italic_ style.
"`_italic_,`" - non formatted text as is "`_italic_,`". 

Feat: good  anchor is " .,:!?\t\n".