### PR TITLE
feat+refactor(android): setting custom notification sound and some minor refactor

### DIFF
--- a/actor-sdk/sdk-core-android/android-sdk/src/main/java/im/actor/sdk/BaseActorSDKDelegate.java
+++ b/actor-sdk/sdk-core-android/android-sdk/src/main/java/im/actor/sdk/BaseActorSDKDelegate.java
@@ -1,7 +1,5 @@
 package im.actor.sdk;
 
-import android.content.Context;
-import android.content.SharedPreferences;
 import android.net.Uri;
 import android.provider.Settings;
 import android.support.v4.app.Fragment;
@@ -10,7 +8,6 @@ import android.view.ViewGroup;
 import org.jetbrains.annotations.Nullable;
 
 import im.actor.core.entity.Peer;
-import im.actor.runtime.android.AndroidContext;
 import im.actor.runtime.android.view.BindedViewHolder;
 import im.actor.sdk.controllers.conversation.ChatFragment;
 import im.actor.sdk.controllers.conversation.attach.AbsAttachFragment;
@@ -21,6 +18,8 @@ import im.actor.sdk.controllers.conversation.messages.content.MessageHolder;
 import im.actor.sdk.controllers.conversation.quote.QuoteFragment;
 import im.actor.sdk.intents.ActorIntent;
 import im.actor.sdk.intents.ActorIntentFragmentActivity;
+
+import static im.actor.sdk.util.ActorSDKMessenger.messenger;
 
 /**
  * Base Implementation of Actor SDK Delegate. This class is recommended to subclass instead
@@ -125,9 +124,8 @@ public class BaseActorSDKDelegate implements ActorSDKDelegate {
     }
 
     public Uri getNotificationSoundForPeer(Peer peer) {
-        SharedPreferences sharedPreferences = AndroidContext.getContext().getSharedPreferences("notifications", Context.MODE_PRIVATE);
 
-        String globalSound = sharedPreferences.getString("userSound_" + peer.getPeerId(), null);
+        String globalSound = messenger().getPreferences().getString("userNotificationSound_" + peer.getPeerId());
         if (globalSound != null) {
             if (globalSound.equals("none")) {
                 return null;
@@ -144,9 +142,7 @@ public class BaseActorSDKDelegate implements ActorSDKDelegate {
     }
 
     public Uri getNotificationSound() {
-        SharedPreferences sharedPreferences = AndroidContext.getContext().getSharedPreferences("notifications", Context.MODE_PRIVATE);
-
-        String globalSound = sharedPreferences.getString("globalSound", null);
+        String globalSound = messenger().getPreferences().getString("globalNotificationSound");
         if (globalSound != null) {
             if (globalSound.equals("none")) {
                 return null;

--- a/actor-sdk/sdk-core-android/android-sdk/src/main/java/im/actor/sdk/BaseActorSDKDelegate.java
+++ b/actor-sdk/sdk-core-android/android-sdk/src/main/java/im/actor/sdk/BaseActorSDKDelegate.java
@@ -1,5 +1,7 @@
 package im.actor.sdk;
 
+import android.content.Context;
+import android.content.SharedPreferences;
 import android.net.Uri;
 import android.provider.Settings;
 import android.support.v4.app.Fragment;
@@ -8,15 +10,15 @@ import android.view.ViewGroup;
 import org.jetbrains.annotations.Nullable;
 
 import im.actor.core.entity.Peer;
+import im.actor.runtime.android.AndroidContext;
 import im.actor.runtime.android.view.BindedViewHolder;
 import im.actor.sdk.controllers.conversation.ChatFragment;
 import im.actor.sdk.controllers.conversation.attach.AbsAttachFragment;
 import im.actor.sdk.controllers.conversation.inputbar.InputBarFragment;
 import im.actor.sdk.controllers.conversation.mentions.AutocompleteFragment;
-import im.actor.sdk.controllers.conversation.messages.content.MessageHolder;
 import im.actor.sdk.controllers.conversation.messages.MessagesAdapter;
+import im.actor.sdk.controllers.conversation.messages.content.MessageHolder;
 import im.actor.sdk.controllers.conversation.quote.QuoteFragment;
-import im.actor.sdk.controllers.settings.BaseGroupInfoActivity;
 import im.actor.sdk.intents.ActorIntent;
 import im.actor.sdk.intents.ActorIntentFragmentActivity;
 
@@ -96,7 +98,7 @@ public class BaseActorSDKDelegate implements ActorSDKDelegate {
     public ActorIntentFragmentActivity getSettingsIntent() {
         return null;
     }
-    
+
     @Override
     public ActorIntentFragmentActivity getChatSettingsIntent() {
         return null;
@@ -123,6 +125,17 @@ public class BaseActorSDKDelegate implements ActorSDKDelegate {
     }
 
     public Uri getNotificationSoundForPeer(Peer peer) {
+        SharedPreferences sharedPreferences = AndroidContext.getContext().getSharedPreferences("notifications", Context.MODE_PRIVATE);
+
+        String globalSound = sharedPreferences.getString("userSound_" + peer.getPeerId(), null);
+        if (globalSound != null) {
+            if (globalSound.equals("none")) {
+                return null;
+            } else {
+                return Uri.parse(globalSound);
+            }
+        }
+
         return getNotificationSound();
     }
 
@@ -131,6 +144,17 @@ public class BaseActorSDKDelegate implements ActorSDKDelegate {
     }
 
     public Uri getNotificationSound() {
+        SharedPreferences sharedPreferences = AndroidContext.getContext().getSharedPreferences("notifications", Context.MODE_PRIVATE);
+
+        String globalSound = sharedPreferences.getString("globalSound", null);
+        if (globalSound != null) {
+            if (globalSound.equals("none")) {
+                return null;
+            } else {
+                return Uri.parse(globalSound);
+            }
+        }
+
         return Settings.System.DEFAULT_NOTIFICATION_URI;
     }
 

--- a/actor-sdk/sdk-core-android/android-sdk/src/main/java/im/actor/sdk/controllers/profile/ProfileFragment.java
+++ b/actor-sdk/sdk-core-android/android-sdk/src/main/java/im/actor/sdk/controllers/profile/ProfileFragment.java
@@ -1,14 +1,18 @@
 package im.actor.sdk.controllers.profile;
 
+import android.app.Activity;
 import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
+import android.media.RingtoneManager;
 import android.net.Uri;
 import android.os.Bundle;
+import android.provider.Settings;
 import android.support.design.widget.Snackbar;
 import android.support.v4.graphics.drawable.DrawableCompat;
 import android.support.v7.app.ActionBar;
@@ -32,24 +36,30 @@ import com.google.i18n.phonenumbers.Phonenumber;
 
 import java.util.ArrayList;
 
+import im.actor.core.entity.Peer;
 import im.actor.core.viewmodel.UserEmail;
+import im.actor.core.viewmodel.UserPhone;
+import im.actor.core.viewmodel.UserVM;
 import im.actor.runtime.mvvm.Value;
 import im.actor.runtime.mvvm.ValueChangedListener;
 import im.actor.sdk.ActorSDK;
 import im.actor.sdk.R;
+import im.actor.sdk.controllers.BaseFragment;
 import im.actor.sdk.controllers.Intents;
 import im.actor.sdk.controllers.fragment.preview.ViewAvatarActivity;
-import im.actor.sdk.controllers.BaseFragment;
 import im.actor.sdk.util.Screen;
+import im.actor.sdk.util.ViewUtils;
 import im.actor.sdk.view.avatar.AvatarView;
-import im.actor.core.entity.Peer;
-import im.actor.core.viewmodel.UserPhone;
-import im.actor.core.viewmodel.UserVM;
 
 import static im.actor.sdk.util.ActorSDKMessenger.messenger;
 import static im.actor.sdk.util.ActorSDKMessenger.users;
 
 public class ProfileFragment extends BaseFragment {
+
+    private SharedPreferences notificationPreferences;
+    private SharedPreferences.Editor notificationPreferencesEditor;
+
+    public static int SOUND_PICKER_REQUEST_CODE = 122;
 
     public static final String EXTRA_UID = "uid";
 
@@ -406,15 +416,60 @@ public class ProfileFragment extends BaseFragment {
             // Notifications
             //
             View notificationContainer = res.findViewById(R.id.notificationsCont);
+            View notificationPickerContainer = res.findViewById(R.id.notificationsPickerCont);
+
             ((TextView) notificationContainer.findViewById(R.id.settings_notifications_title)).setTextColor(style.getTextPrimaryColor());
             final SwitchCompat notificationEnable = (SwitchCompat) res.findViewById(R.id.enableNotifications);
-            notificationEnable.setChecked(messenger().isNotificationsEnabled(Peer.user(user.getId())));
-            notificationEnable.setOnCheckedChangeListener((buttonView, isChecked) -> messenger().changeNotificationsEnabled(Peer.user(user.getId()), isChecked));
+            Peer peer = Peer.user(user.getId());
+            notificationEnable.setChecked(messenger().isNotificationsEnabled(peer));
+            if (messenger().isNotificationsEnabled(peer)) {
+                ViewUtils.showView(notificationPickerContainer, false);
+            } else {
+                ViewUtils.goneView(notificationPickerContainer, false);
+            }
+            notificationEnable.setOnCheckedChangeListener((buttonView, isChecked) -> {
+                messenger().changeNotificationsEnabled(Peer.user(user.getId()), isChecked);
+
+                if (isChecked) {
+                    ViewUtils.showView(notificationPickerContainer, false);
+                } else {
+                    ViewUtils.goneView(notificationPickerContainer, false);
+                }
+            });
             notificationContainer.setOnClickListener(v -> notificationEnable.setChecked(!notificationEnable.isChecked()));
             ImageView iconView = (ImageView) res.findViewById(R.id.settings_notification_icon);
             Drawable drawable = DrawableCompat.wrap(getResources().getDrawable(R.drawable.ic_list_black_24dp));
             DrawableCompat.setTint(drawable, style.getSettingsIconColor());
             iconView.setImageDrawable(drawable);
+
+            notificationPreferences = getActivity().getSharedPreferences("notifications", Context.MODE_PRIVATE);
+            notificationPreferencesEditor = notificationPreferences.edit();
+
+            ((TextView) notificationPickerContainer.findViewById(R.id.settings_notifications_picker_title)).setTextColor(style.getTextPrimaryColor());
+            notificationPickerContainer.setOnClickListener(view -> {
+                Intent intent = new Intent(RingtoneManager.ACTION_RINGTONE_PICKER);
+                intent.putExtra(RingtoneManager.EXTRA_RINGTONE_TYPE, RingtoneManager.TYPE_NOTIFICATION);
+                intent.putExtra(RingtoneManager.EXTRA_RINGTONE_SHOW_DEFAULT, true);
+                intent.putExtra(RingtoneManager.EXTRA_RINGTONE_DEFAULT_URI, RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION));
+
+                Uri currentSound = null;
+                String defaultPath = null;
+                Uri defaultUri = Settings.System.DEFAULT_NOTIFICATION_URI;
+                if (defaultUri != null) {
+                    defaultPath = defaultUri.getPath();
+                }
+
+                String path = notificationPreferences.getString("userSound_" + uid, defaultPath);
+                if (path != null && !path.equals("none")) {
+                    if (path.equals(defaultPath)) {
+                        currentSound = defaultUri;
+                    } else {
+                        currentSound = Uri.parse(path);
+                    }
+                }
+                intent.putExtra(RingtoneManager.EXTRA_RINGTONE_EXISTING_URI, currentSound);
+                startActivityForResult(intent, SOUND_PICKER_REQUEST_CODE);
+            });
 
             //
             // Block
@@ -457,6 +512,20 @@ public class ProfileFragment extends BaseFragment {
         updateBar(scrollView.getScrollY());
 
         return res;
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        if (resultCode == Activity.RESULT_OK && requestCode == SOUND_PICKER_REQUEST_CODE) {
+            Uri ringtone = data.getParcelableExtra(RingtoneManager.EXTRA_RINGTONE_PICKED_URI);
+
+            if (ringtone != null) {
+                notificationPreferencesEditor.putString("userSound_" + uid, ringtone.toString());
+            } else {
+                notificationPreferencesEditor.putString("userSound" + uid, "none");
+            }
+            notificationPreferencesEditor.commit();
+        }
     }
 
     @Override

--- a/actor-sdk/sdk-core-android/android-sdk/src/main/java/im/actor/sdk/controllers/profile/ProfileFragment.java
+++ b/actor-sdk/sdk-core-android/android-sdk/src/main/java/im/actor/sdk/controllers/profile/ProfileFragment.java
@@ -5,7 +5,6 @@ import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.Intent;
-import android.content.SharedPreferences;
 import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
@@ -55,9 +54,6 @@ import static im.actor.sdk.util.ActorSDKMessenger.messenger;
 import static im.actor.sdk.util.ActorSDKMessenger.users;
 
 public class ProfileFragment extends BaseFragment {
-
-    private SharedPreferences notificationPreferences;
-    private SharedPreferences.Editor notificationPreferencesEditor;
 
     public static int SOUND_PICKER_REQUEST_CODE = 122;
 
@@ -442,9 +438,6 @@ public class ProfileFragment extends BaseFragment {
             DrawableCompat.setTint(drawable, style.getSettingsIconColor());
             iconView.setImageDrawable(drawable);
 
-            notificationPreferences = getActivity().getSharedPreferences("notifications", Context.MODE_PRIVATE);
-            notificationPreferencesEditor = notificationPreferences.edit();
-
             ((TextView) notificationPickerContainer.findViewById(R.id.settings_notifications_picker_title)).setTextColor(style.getTextPrimaryColor());
             notificationPickerContainer.setOnClickListener(view -> {
                 Intent intent = new Intent(RingtoneManager.ACTION_RINGTONE_PICKER);
@@ -459,7 +452,10 @@ public class ProfileFragment extends BaseFragment {
                     defaultPath = defaultUri.getPath();
                 }
 
-                String path = notificationPreferences.getString("userSound_" + uid, defaultPath);
+                String path = messenger().getPreferences().getString("userNotificationSound_" + uid);
+                if (path == null) {
+                    path = defaultPath;
+                }
                 if (path != null && !path.equals("none")) {
                     if (path.equals(defaultPath)) {
                         currentSound = defaultUri;
@@ -520,11 +516,10 @@ public class ProfileFragment extends BaseFragment {
             Uri ringtone = data.getParcelableExtra(RingtoneManager.EXTRA_RINGTONE_PICKED_URI);
 
             if (ringtone != null) {
-                notificationPreferencesEditor.putString("userSound_" + uid, ringtone.toString());
+                messenger().getPreferences().putString("userNotificationSound_" + uid, ringtone.toString());
             } else {
-                notificationPreferencesEditor.putString("userSound" + uid, "none");
+                messenger().getPreferences().putString("userNotificationSound_" + uid, "none");
             }
-            notificationPreferencesEditor.commit();
         }
     }
 

--- a/actor-sdk/sdk-core-android/android-sdk/src/main/java/im/actor/sdk/controllers/root/RootActivity.java
+++ b/actor-sdk/sdk-core-android/android-sdk/src/main/java/im/actor/sdk/controllers/root/RootActivity.java
@@ -1,35 +1,15 @@
 package im.actor.sdk.controllers.root;
 
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.graphics.drawable.ColorDrawable;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
-import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.Toolbar;
-import android.widget.Toast;
 
-import java.io.UnsupportedEncodingException;
-
-import im.actor.core.entity.Peer;
-import im.actor.core.viewmodel.CommandCallback;
-import im.actor.core.viewmodel.GroupVM;
-import im.actor.runtime.HTTP;
-import im.actor.runtime.android.AndroidContext;
-import im.actor.runtime.function.Consumer;
-import im.actor.runtime.http.HTTPResponse;
-import im.actor.runtime.json.JSONException;
-import im.actor.runtime.json.JSONObject;
 import im.actor.sdk.ActorSDK;
 import im.actor.sdk.R;
-import im.actor.sdk.controllers.Intents;
 import im.actor.sdk.controllers.activity.BaseFragmentActivity;
 import im.actor.sdk.controllers.tools.InviteHandler;
-import im.actor.sdk.intents.ActorIntent;
-import im.actor.sdk.intents.ActorIntentActivity;
-
-import static im.actor.sdk.util.ActorSDKMessenger.groups;
-import static im.actor.sdk.util.ActorSDKMessenger.messenger;
 
 /**
  * Root Activity of Application
@@ -69,5 +49,4 @@ public class RootActivity extends BaseFragmentActivity {
         super.onNewIntent(intent);
         InviteHandler.handleIntent(this, intent);
     }
-
 }

--- a/actor-sdk/sdk-core-android/android-sdk/src/main/java/im/actor/sdk/controllers/settings/NotificationsFragment.java
+++ b/actor-sdk/sdk-core-android/android-sdk/src/main/java/im/actor/sdk/controllers/settings/NotificationsFragment.java
@@ -33,22 +33,13 @@ public class NotificationsFragment extends BaseFragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View res = inflater.inflate(R.layout.fr_settings_notifications, container, false);
         res.setBackgroundColor(ActorSDK.sharedActor().style.getMainBackgroundColor());
-        res.findViewById(R.id.divider).setBackgroundColor(ActorSDK.sharedActor().style.getDividerColor());
-        res.findViewById(R.id.divider1).setBackgroundColor(ActorSDK.sharedActor().style.getDividerColor());
-        res.findViewById(R.id.divider2).setBackgroundColor(ActorSDK.sharedActor().style.getDividerColor());
-        res.findViewById(R.id.divider3).setBackgroundColor(ActorSDK.sharedActor().style.getDividerColor());
-        res.findViewById(R.id.divider4).setBackgroundColor(ActorSDK.sharedActor().style.getDividerColor());
-        res.findViewById(R.id.divider5).setBackgroundColor(ActorSDK.sharedActor().style.getDividerColor());
 
         // Conversation tone
         final CheckBox enableTones = (CheckBox) res.findViewById(R.id.enableConversationTones);
         enableTones.setChecked(messenger().isConversationTonesEnabled());
-        View.OnClickListener enableTonesListener = new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                messenger().changeConversationTonesEnabled(!messenger().isConversationTonesEnabled());
-                enableTones.setChecked(messenger().isConversationTonesEnabled());
-            }
+        View.OnClickListener enableTonesListener = v -> {
+            messenger().changeConversationTonesEnabled(!messenger().isConversationTonesEnabled());
+            enableTones.setChecked(messenger().isConversationTonesEnabled());
         };
         ActorStyle style = ActorSDK.sharedActor().style;
         ((TextView) res.findViewById(R.id.settings_conversation_tones_title)).setTextColor(style.getTextPrimaryColor());
@@ -59,12 +50,9 @@ public class NotificationsFragment extends BaseFragment {
         // Vibration
         final CheckBox enableVibration = (CheckBox) res.findViewById(R.id.enableVibration);
         enableVibration.setChecked(messenger().isNotificationVibrationEnabled());
-        View.OnClickListener enableVibrationListener = new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                messenger().changeNotificationVibrationEnabled(!messenger().isNotificationVibrationEnabled());
-                enableVibration.setChecked(messenger().isNotificationVibrationEnabled());
-            }
+        View.OnClickListener enableVibrationListener = v -> {
+            messenger().changeNotificationVibrationEnabled(!messenger().isNotificationVibrationEnabled());
+            enableVibration.setChecked(messenger().isNotificationVibrationEnabled());
         };
         enableVibration.setOnClickListener(enableVibrationListener);
         res.findViewById(R.id.vibrationCont).setOnClickListener(enableVibrationListener);
@@ -74,12 +62,9 @@ public class NotificationsFragment extends BaseFragment {
         // Group
         final CheckBox enableGroup = (CheckBox) res.findViewById(R.id.enableGroup);
         enableGroup.setChecked(messenger().isGroupNotificationsEnabled());
-        View.OnClickListener enableGroupListener = new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                messenger().changeGroupNotificationsEnabled(!messenger().isGroupNotificationsEnabled());
-                enableGroup.setChecked(messenger().isGroupNotificationsEnabled());
-            }
+        View.OnClickListener enableGroupListener = v -> {
+            messenger().changeGroupNotificationsEnabled(!messenger().isGroupNotificationsEnabled());
+            enableGroup.setChecked(messenger().isGroupNotificationsEnabled());
         };
         enableGroup.setOnClickListener(enableGroupListener);
         res.findViewById(R.id.groupCont).setOnClickListener(enableGroupListener);
@@ -89,12 +74,9 @@ public class NotificationsFragment extends BaseFragment {
         // Mentions
         final CheckBox enableGroupMentions = (CheckBox) res.findViewById(R.id.enableGroupMentions);
         enableGroupMentions.setChecked(messenger().isGroupNotificationsOnlyMentionsEnabled());
-        View.OnClickListener enableGroupMentionsListener = new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                messenger().changeGroupNotificationsOnlyMentionsEnabled(!messenger().isGroupNotificationsOnlyMentionsEnabled());
-                enableGroupMentions.setChecked(messenger().isGroupNotificationsOnlyMentionsEnabled());
-            }
+        View.OnClickListener enableGroupMentionsListener = v -> {
+            messenger().changeGroupNotificationsOnlyMentionsEnabled(!messenger().isGroupNotificationsOnlyMentionsEnabled());
+            enableGroupMentions.setChecked(messenger().isGroupNotificationsOnlyMentionsEnabled());
         };
         enableGroupMentions.setOnClickListener(enableGroupMentionsListener);
         res.findViewById(R.id.groupMentionsCont).setOnClickListener(enableGroupMentionsListener);
@@ -104,12 +86,9 @@ public class NotificationsFragment extends BaseFragment {
         // Names and messages
         final CheckBox enableText = (CheckBox) res.findViewById(R.id.enableTitles);
         enableText.setChecked(messenger().isShowNotificationsText());
-        View.OnClickListener enableTextListener = new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                messenger().changeShowNotificationTextEnabled(!messenger().isShowNotificationsText());
-                enableText.setChecked(messenger().isShowNotificationsText());
-            }
+        View.OnClickListener enableTextListener = v -> {
+            messenger().changeShowNotificationTextEnabled(!messenger().isShowNotificationsText());
+            enableText.setChecked(messenger().isShowNotificationsText());
         };
         enableText.setOnClickListener(enableTextListener);
         res.findViewById(R.id.titlesCont).setOnClickListener(enableTextListener);
@@ -119,20 +98,17 @@ public class NotificationsFragment extends BaseFragment {
         // Sound
         final CheckBox enableSound = (CheckBox) res.findViewById(R.id.enableSound);
         enableSound.setChecked(messenger().isNotificationSoundEnabled());
-        View.OnClickListener enableSoundListener = new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                messenger().changeNotificationSoundEnabled(!messenger().isNotificationSoundEnabled());
-                enableSound.setChecked(messenger().isNotificationSoundEnabled());
+        View.OnClickListener enableSoundListener = v -> {
+            messenger().changeNotificationSoundEnabled(!messenger().isNotificationSoundEnabled());
+            enableSound.setChecked(messenger().isNotificationSoundEnabled());
 
-                //show/hide sound picker
-                View cont = res.findViewById(R.id.soundPickerCont);
-                View div = res.findViewById(R.id.divider5);
-                if (messenger().isNotificationSoundEnabled()) {
-                    ViewUtils.showViews(cont, div);
-                } else {
-                    ViewUtils.goneViews(cont, div);
-                }
+            //show/hide sound picker
+            View cont = res.findViewById(R.id.soundPickerCont);
+            View div = res.findViewById(R.id.divider);
+            if (messenger().isNotificationSoundEnabled()) {
+                ViewUtils.showViews(cont, div);
+            } else {
+                ViewUtils.goneViews(cont, div);
             }
         };
         enableSound.setOnClickListener(enableSoundListener);
@@ -143,32 +119,29 @@ public class NotificationsFragment extends BaseFragment {
         // Sound picker
         notificationPreferences = getActivity().getSharedPreferences("notifications", Context.MODE_PRIVATE);
         notificationPreferencesEditor = notificationPreferences.edit();
-        View.OnClickListener soundPickerListener = new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                Intent intent = new Intent(RingtoneManager.ACTION_RINGTONE_PICKER);
-                intent.putExtra(RingtoneManager.EXTRA_RINGTONE_TYPE, RingtoneManager.TYPE_NOTIFICATION);
-                intent.putExtra(RingtoneManager.EXTRA_RINGTONE_SHOW_DEFAULT, true);
-                intent.putExtra(RingtoneManager.EXTRA_RINGTONE_DEFAULT_URI, RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION));
+        View.OnClickListener soundPickerListener = v -> {
+            Intent intent = new Intent(RingtoneManager.ACTION_RINGTONE_PICKER);
+            intent.putExtra(RingtoneManager.EXTRA_RINGTONE_TYPE, RingtoneManager.TYPE_NOTIFICATION);
+            intent.putExtra(RingtoneManager.EXTRA_RINGTONE_SHOW_DEFAULT, true);
+            intent.putExtra(RingtoneManager.EXTRA_RINGTONE_DEFAULT_URI, RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION));
 
-                Uri currentSound = null;
-                String defaultPath = null;
-                Uri defaultUri = Settings.System.DEFAULT_NOTIFICATION_URI;
-                if (defaultUri != null) {
-                    defaultPath = defaultUri.getPath();
-                }
-
-                String path = notificationPreferences.getString("globalSound", defaultPath);
-                if (path != null && !path.equals("none")) {
-                    if (path.equals(defaultPath)) {
-                        currentSound = defaultUri;
-                    } else {
-                        currentSound = Uri.parse(path);
-                    }
-                }
-                intent.putExtra(RingtoneManager.EXTRA_RINGTONE_EXISTING_URI, currentSound);
-                startActivityForResult(intent, SOUND_PICKER_REQUEST_CODE);
+            Uri currentSound = null;
+            String defaultPath = null;
+            Uri defaultUri = Settings.System.DEFAULT_NOTIFICATION_URI;
+            if (defaultUri != null) {
+                defaultPath = defaultUri.getPath();
             }
+
+            String path = notificationPreferences.getString("globalSound", defaultPath);
+            if (path != null && !path.equals("none")) {
+                if (path.equals(defaultPath)) {
+                    currentSound = defaultUri;
+                } else {
+                    currentSound = Uri.parse(path);
+                }
+            }
+            intent.putExtra(RingtoneManager.EXTRA_RINGTONE_EXISTING_URI, currentSound);
+            startActivityForResult(intent, SOUND_PICKER_REQUEST_CODE);
         };
         res.findViewById(R.id.soundPickerCont).setOnClickListener(soundPickerListener);
         ((TextView) res.findViewById(R.id.settings_sound_picker_title)).setTextColor(style.getTextPrimaryColor());

--- a/actor-sdk/sdk-core-android/android-sdk/src/main/java/im/actor/sdk/controllers/settings/NotificationsFragment.java
+++ b/actor-sdk/sdk-core-android/android-sdk/src/main/java/im/actor/sdk/controllers/settings/NotificationsFragment.java
@@ -96,6 +96,15 @@ public class NotificationsFragment extends BaseFragment {
         ((TextView) res.findViewById(R.id.settings_titles_hint)).setTextColor(style.getTextSecondaryColor());
 
         // Sound
+        View soundPickerCont = res.findViewById(R.id.soundPickerCont);
+        View soundPickerDivider = res.findViewById(R.id.divider);
+
+        if (messenger().isNotificationSoundEnabled()) {
+            ViewUtils.showViews(false, soundPickerCont, soundPickerDivider);
+        } else {
+            ViewUtils.goneViews(false, soundPickerCont, soundPickerDivider);
+        }
+
         final CheckBox enableSound = (CheckBox) res.findViewById(R.id.enableSound);
         enableSound.setChecked(messenger().isNotificationSoundEnabled());
         View.OnClickListener enableSoundListener = v -> {
@@ -103,12 +112,10 @@ public class NotificationsFragment extends BaseFragment {
             enableSound.setChecked(messenger().isNotificationSoundEnabled());
 
             //show/hide sound picker
-            View cont = res.findViewById(R.id.soundPickerCont);
-            View div = res.findViewById(R.id.divider);
             if (messenger().isNotificationSoundEnabled()) {
-                ViewUtils.showViews(cont, div);
+                ViewUtils.showViews(soundPickerCont, soundPickerDivider);
             } else {
-                ViewUtils.goneViews(cont, div);
+                ViewUtils.goneViews(soundPickerCont, soundPickerDivider);
             }
         };
         enableSound.setOnClickListener(enableSoundListener);

--- a/actor-sdk/sdk-core-android/android-sdk/src/main/java/im/actor/sdk/controllers/settings/NotificationsFragment.java
+++ b/actor-sdk/sdk-core-android/android-sdk/src/main/java/im/actor/sdk/controllers/settings/NotificationsFragment.java
@@ -1,9 +1,7 @@
 package im.actor.sdk.controllers.settings;
 
 import android.app.Activity;
-import android.content.Context;
 import android.content.Intent;
-import android.content.SharedPreferences;
 import android.media.RingtoneManager;
 import android.net.Uri;
 import android.os.Bundle;
@@ -23,9 +21,6 @@ import im.actor.sdk.util.ViewUtils;
 import static im.actor.sdk.util.ActorSDKMessenger.messenger;
 
 public class NotificationsFragment extends BaseFragment {
-
-    private SharedPreferences notificationPreferences;
-    private SharedPreferences.Editor notificationPreferencesEditor;
 
     public static int SOUND_PICKER_REQUEST_CODE = 122;
 
@@ -124,8 +119,6 @@ public class NotificationsFragment extends BaseFragment {
         ((TextView) res.findViewById(R.id.settings_sound_hint)).setTextColor(style.getTextSecondaryColor());
 
         // Sound picker
-        notificationPreferences = getActivity().getSharedPreferences("notifications", Context.MODE_PRIVATE);
-        notificationPreferencesEditor = notificationPreferences.edit();
         View.OnClickListener soundPickerListener = v -> {
             Intent intent = new Intent(RingtoneManager.ACTION_RINGTONE_PICKER);
             intent.putExtra(RingtoneManager.EXTRA_RINGTONE_TYPE, RingtoneManager.TYPE_NOTIFICATION);
@@ -139,7 +132,10 @@ public class NotificationsFragment extends BaseFragment {
                 defaultPath = defaultUri.getPath();
             }
 
-            String path = notificationPreferences.getString("globalSound", defaultPath);
+            String path = messenger().getPreferences().getString("globalNotificationSound");
+            if (path == null) {
+                path = defaultPath;
+            }
             if (path != null && !path.equals("none")) {
                 if (path.equals(defaultPath)) {
                     currentSound = defaultUri;
@@ -162,11 +158,10 @@ public class NotificationsFragment extends BaseFragment {
             Uri ringtone = data.getParcelableExtra(RingtoneManager.EXTRA_RINGTONE_PICKED_URI);
 
             if (ringtone != null) {
-                notificationPreferencesEditor.putString("globalSound", ringtone.toString());
+                messenger().getPreferences().putString("globalNotificationSound", ringtone.toString());
             } else {
-                notificationPreferencesEditor.putString("globalSound", "none");
+                messenger().getPreferences().putString("globalNotificationSound", "none");
             }
-            notificationPreferencesEditor.commit();
         }
     }
 }

--- a/actor-sdk/sdk-core-android/android-sdk/src/main/java/im/actor/sdk/util/ViewUtils.java
+++ b/actor-sdk/sdk-core-android/android-sdk/src/main/java/im/actor/sdk/util/ViewUtils.java
@@ -1,14 +1,9 @@
 package im.actor.sdk.util;
 
-import android.graphics.Color;
-import android.os.Handler;
 import android.view.View;
 import android.view.animation.AlphaAnimation;
 import android.view.animation.Animation;
-import android.view.animation.CycleInterpolator;
 import android.view.animation.ScaleAnimation;
-import android.view.animation.Transformation;
-import android.widget.AbsListView;
 
 import im.actor.sdk.view.MaterialInterpolator;
 
@@ -40,6 +35,20 @@ public class ViewUtils {
         }
     }
 
+    public static void goneViews(View... views) {
+        goneViews(true, views);
+    }
+
+    public static void goneViews(boolean isAnimated, View... views) {
+        goneViews(isAnimated, true, views);
+    }
+
+    public static void goneViews(boolean isAnimated, boolean isSlow, View... views) {
+        for (View view : views) {
+            goneView(view, isAnimated, isSlow);
+        }
+    }
+
     public static void hideView(View view) {
         hideView(view, true);
     }
@@ -64,6 +73,20 @@ public class ViewUtils {
             }
         } else {
             view.setVisibility(View.INVISIBLE);
+        }
+    }
+
+    public static void hideViews(View... views) {
+        hideViews(true, views);
+    }
+
+    public static void hideViews(boolean isAnimated, View... views) {
+        hideViews(isAnimated, true, views);
+    }
+
+    public static void hideViews(boolean isAnimated, boolean isSlow, View... views) {
+        for (View view : views) {
+            hideView(view, isAnimated, isSlow);
         }
     }
 
@@ -125,6 +148,20 @@ public class ViewUtils {
             }
         } else {
             view.setVisibility(View.VISIBLE);
+        }
+    }
+
+    public static void showViews(View... views) {
+        showViews(true, views);
+    }
+
+    public static void showViews(boolean isAnimated, View... views) {
+        showViews(isAnimated, true, views);
+    }
+
+    public static void showViews(boolean isAnimated, boolean isSlow, View... views) {
+        for (View view : views) {
+            showView(view, isAnimated, isSlow);
         }
     }
 

--- a/actor-sdk/sdk-core-android/android-sdk/src/main/res/layout/fr_settings_notifications.xml
+++ b/actor-sdk/sdk-core-android/android-sdk/src/main/res/layout/fr_settings_notifications.xml
@@ -57,54 +57,6 @@
                 android:gravity="center_vertical" />
         </LinearLayout>
 
-
-        <View
-            android:id="@+id/divider"
-            android:layout_width="match_parent"
-            android:layout_height="@dimen/div_size" />
-
-        <LinearLayout
-            android:id="@+id/soundCont"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="@drawable/selector"
-            android:gravity="center_vertical"
-            android:paddingBottom="@dimen/settings_content_padding"
-            android:paddingLeft="@dimen/settings_content_padding"
-            android:paddingRight="@dimen/settings_content_padding"
-            android:paddingTop="@dimen/settings_content_padding">
-
-            <LinearLayout
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:orientation="vertical">
-
-                <TextView
-                    android:id="@+id/settings_sound_title"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="@string/not_sound"
-                    android:textSize="@dimen/text_primary" />
-
-                <TextView
-                    android:id="@+id/settings_sound_hint"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="@string/not_sound_subtitle"
-                    android:textSize="@dimen/text_secondary" />
-            </LinearLayout>
-
-
-            <CheckBox
-                android:id="@+id/enableSound"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginLeft="@dimen/settings_content_padding"
-                android:layout_marginRight="@dimen/settings_content_padding"
-                android:gravity="center_vertical" />
-        </LinearLayout>
-
         <View
             android:id="@+id/divider1"
             android:layout_width="match_parent"
@@ -291,5 +243,91 @@
                 android:layout_marginRight="@dimen/settings_content_padding"
                 android:gravity="center_vertical" />
         </LinearLayout>
+
+        <View
+            android:id="@+id/divider"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/div_size" />
+
+        <LinearLayout
+            android:id="@+id/soundCont"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@drawable/selector"
+            android:gravity="center_vertical"
+            android:paddingBottom="@dimen/settings_content_padding"
+            android:paddingLeft="@dimen/settings_content_padding"
+            android:paddingRight="@dimen/settings_content_padding"
+            android:paddingTop="@dimen/settings_content_padding">
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <TextView
+                    android:id="@+id/settings_sound_title"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/not_sound"
+                    android:textSize="@dimen/text_primary" />
+
+                <TextView
+                    android:id="@+id/settings_sound_hint"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/not_sound_subtitle"
+                    android:textSize="@dimen/text_secondary" />
+            </LinearLayout>
+
+
+            <CheckBox
+                android:id="@+id/enableSound"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="@dimen/settings_content_padding"
+                android:layout_marginRight="@dimen/settings_content_padding"
+                android:gravity="center_vertical" />
+        </LinearLayout>
+
+        <View
+            android:id="@+id/divider5"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/div_size" />
+
+        <LinearLayout
+            android:id="@+id/soundPickerCont"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@drawable/selector"
+            android:gravity="center_vertical"
+            android:paddingBottom="@dimen/settings_content_padding"
+            android:paddingLeft="@dimen/settings_content_padding"
+            android:paddingRight="@dimen/settings_content_padding"
+            android:paddingTop="@dimen/settings_content_padding">
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <TextView
+                    android:id="@+id/settings_sound_picker_title"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/not_sound_picker"
+                    android:textSize="@dimen/text_primary" />
+
+                <TextView
+                    android:id="@+id/settings_sound_picker_hint"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/not_sound_picker_subtitle"
+                    android:textSize="@dimen/text_secondary" />
+            </LinearLayout>
+        </LinearLayout>
+
     </LinearLayout>
 </ScrollView>

--- a/actor-sdk/sdk-core-android/android-sdk/src/main/res/layout/fr_settings_notifications.xml
+++ b/actor-sdk/sdk-core-android/android-sdk/src/main/res/layout/fr_settings_notifications.xml
@@ -57,10 +57,9 @@
                 android:gravity="center_vertical" />
         </LinearLayout>
 
-        <View
-            android:id="@+id/divider1"
+        <im.actor.sdk.view.DividerView
             android:layout_width="match_parent"
-            android:layout_height="@dimen/div_size" />
+            android:layout_height="@dimen/div_size"/>
 
         <LinearLayout
             android:id="@+id/vibrationCont"
@@ -104,10 +103,9 @@
                 android:gravity="center_vertical" />
         </LinearLayout>
 
-        <View
-            android:id="@+id/divider2"
+        <im.actor.sdk.view.DividerView
             android:layout_width="match_parent"
-            android:layout_height="@dimen/div_size" />
+            android:layout_height="@dimen/div_size"/>
 
         <LinearLayout
             android:id="@+id/groupCont"
@@ -151,10 +149,9 @@
                 android:gravity="center_vertical" />
         </LinearLayout>
 
-        <View
-            android:id="@+id/divider3"
+        <im.actor.sdk.view.DividerView
             android:layout_width="match_parent"
-            android:layout_height="@dimen/div_size" />
+            android:layout_height="@dimen/div_size"/>
 
         <LinearLayout
             android:id="@+id/groupMentionsCont"
@@ -198,10 +195,9 @@
                 android:gravity="center_vertical" />
         </LinearLayout>
 
-        <View
-            android:id="@+id/divider4"
+        <im.actor.sdk.view.DividerView
             android:layout_width="match_parent"
-            android:layout_height="@dimen/div_size" />
+            android:layout_height="@dimen/div_size"/>
 
         <LinearLayout
             android:id="@+id/titlesCont"
@@ -244,10 +240,9 @@
                 android:gravity="center_vertical" />
         </LinearLayout>
 
-        <View
-            android:id="@+id/divider"
+        <im.actor.sdk.view.DividerView
             android:layout_width="match_parent"
-            android:layout_height="@dimen/div_size" />
+            android:layout_height="@dimen/div_size"/>
 
         <LinearLayout
             android:id="@+id/soundCont"
@@ -291,10 +286,10 @@
                 android:gravity="center_vertical" />
         </LinearLayout>
 
-        <View
-            android:id="@+id/divider5"
+        <im.actor.sdk.view.DividerView
+            android:id="@+id/divider"
             android:layout_width="match_parent"
-            android:layout_height="@dimen/div_size" />
+            android:layout_height="@dimen/div_size"/>
 
         <LinearLayout
             android:id="@+id/soundPickerCont"

--- a/actor-sdk/sdk-core-android/android-sdk/src/main/res/layout/fragment_profile.xml
+++ b/actor-sdk/sdk-core-android/android-sdk/src/main/res/layout/fragment_profile.xml
@@ -184,6 +184,30 @@
                 android:layout_height="wrap_content" />
         </LinearLayout>
 
+        <LinearLayout
+            android:id="@+id/notificationsPickerCont"
+            android:layout_width="match_parent"
+            android:layout_height="48dp"
+            android:background="@drawable/selector"
+            android:paddingRight="8dp">
+
+            <View
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:layout_marginLeft="16dp"
+                android:layout_marginRight="32dp"
+                android:layout_marginTop="12dp" />
+
+            <TextView
+                android:id="@+id/settings_notifications_picker_title"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:gravity="center_vertical"
+                android:text="@string/profile_settings_notifications_picker"
+                android:textSize="16sp" />
+        </LinearLayout>
+
         <im.actor.sdk.view.DividerView
             android:id="@+id/divider"
             android:layout_width="match_parent"

--- a/actor-sdk/sdk-core-android/android-sdk/src/main/res/values/ui_text.xml
+++ b/actor-sdk/sdk-core-android/android-sdk/src/main/res/values/ui_text.xml
@@ -308,6 +308,7 @@
     <string name="profile_shared_media">Media</string>
     <string name="profile_settings_header">Settings</string>
     <string name="profile_settings_notifications">Notifications</string>
+    <string name="profile_settings_notifications_picker">Notifications sound</string>
     <string name="profile_settings_block">Block user</string>
     <string name="profile_settings_unblock">Unblock user</string>
     <string name="profile_settings_block_confirm">Block {user}?</string>
@@ -483,8 +484,7 @@
     <string name="not_title">Notifications</string>
     <string name="not_conv_tones">Conversation tones</string>
     <string name="not_conv_tones_subtitle">Play sounds for incoming and outgoing messages.</string>
-    <string name="not_sound">Sound</string>
-    <string name="not_sound_subtitle">Enable notification sounds</string>
+
     <string name="not_vibration">Vibration</string>
     <string name="not_vibration_subtitle">Enable vibration in notifications</string>
     <string name="not_group">Group</string>
@@ -493,6 +493,10 @@
     <string name="not_group_mentions_subtitle">Enable group notifications only for mentions</string>
     <string name="not_show_text">Show names and messages</string>
     <string name="not_show_text_subtitle">Show message text and sender name in notification panel</string>
+    <string name="not_sound">Sound</string>
+    <string name="not_sound_subtitle">Enable notification sounds</string>
+    <string name="not_sound_picker">Set sound</string>
+    <string name="not_sound_picker_subtitle">Set notification sound</string>
     <string name="notification_multiple_canversations_after_msg_count">" messages in "</string>
     <string name="notifications_multiple_canversations_after_coversations_count">" chats"</string>
     <string name="notifications_single_conversation_аfter_messages_count">" messages"</string>


### PR DESCRIPTION
Added feature to android-sdk for support custom notification sounds. For Global notifications and per peer. 
Returning notification sound URI's in BaseActorSDKDelegate (getNotificationSound & getNotificationSoundForPeer). URI paths saved in SharedPreferences (preferences file is "notifications"). 

Picker views will be disabled if notifications are disabled.

Also I made some refactors in NotificationsFragment:
Layout was using `View` class for dividers. Changed to `DividerView`.
Converted `onClick` to lambdas.

